### PR TITLE
Enable altbootcmd

### DIFF
--- a/include/env_mender.h
+++ b/include/env_mender.h
@@ -331,6 +331,7 @@
     MENDER_UBI_SETTINGS                                                 \
     MENDER_UNAME_BOOT                                                   \
                                                                         \
+    MENDER_DEFAULT_ALTBOOTCMD						\
     "bootlimit=1\0"                                                     \
     "bootcount=0\0"                                                     \
                                                                         \


### PR DESCRIPTION
Hello and thank you for this branch of uboot-mender: we are also using uEnv.txt file to load uboot overlays and this came as a bless.
during our integration tests we noticed MENDER_DEFAULT_ALTBOOTCMD was missing in MENDER_DEFAULT_ALTBOOTCMD. This way altbootcmd stays empty and the system is unable to rollback